### PR TITLE
consumer: Switch to Poll()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: vet fmt test
 	go build
 
 test:
-	test/end-to-end
+	test/end-to-end -v
 
 lint:
 	golint

--- a/kafka.json.sample
+++ b/kafka.json.sample
@@ -6,10 +6,11 @@
    "log.connection.close": false
  },
  "consumer": {
-   "go.events.channel.enable": true,
-   "go.application.rebalance.enable": true,
+   "go.events.channel.enable": false,
+   "go.application.rebalance.enable": false,
    "enable.auto.commit": false,
-   "auto.offset.reset": "latest"
+   "auto.offset.reset": "latest",
+   "enable.partition.eof": false
  },
  "producer": {
    "go.delivery.reports": true

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -14,7 +14,7 @@ host, port = host_port[0], Integer(host_port[1])
 CLIENT_DEFAULTS = { host: host, port: port }
 FLUSH_TIMEOUT = 5000
 CONSUME_RETRIES = 3
-CONSUME_TIMEOUT = 2
+CONSUME_TIMEOUT = 1
 
 class TestRafka < Minitest::Test
   def setup
@@ -158,7 +158,7 @@ class TestRafka < Minitest::Test
   def test_cgroup_reconnect_many_partitions
     partitions = 4
     input_size = 20
-    reconsumes_tolerated = partitions
+    reconsumes_tolerated = partitions + 2
     flunk "input_size must be even, given: #{input_size}" if input_size.odd?
 
     with_new_topic(partitions: partitions) do |topic|

--- a/test/kafka.test.json
+++ b/test/kafka.test.json
@@ -2,15 +2,16 @@
  "general": {
    "api.version.request": true,
    "bootstrap.servers": "kc1.docker,kc2.docker",
-   "session.timeout.ms": 3000,
+   "session.timeout.ms": 2000,
    "log.connection.close": false,
    "heartbeat.interval.ms": 500
  },
  "consumer": {
-   "go.events.channel.enable": true,
-   "go.application.rebalance.enable": true,
+   "go.events.channel.enable": false,
+   "go.application.rebalance.enable": false,
    "enable.auto.commit": false,
-   "auto.offset.reset": "earliest"
+   "auto.offset.reset": "earliest",
+   "enable.partition.eof": false
  },
  "producer": {
    "go.delivery.reports": true,


### PR DESCRIPTION
Using Poll() means we have a more direct mapping to librdkafka functionality. Poll may also prioritize messages from Kafka, whereas with the channel-based approach we may end up with outdated events.