### PR TITLE
Add initial Go tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v0.9.4"
 
 [[projects]]
+  name = "github.com/go-redis/redis"
+  packages = [".","internal","internal/consistenthash","internal/hashtag","internal/pool","internal/proto"]
+  revision = "da63fe7def48e378caf9539abf64b9b1e37bc01e"
+  version = "v6.5.3"
+
+[[projects]]
   name = "github.com/secmask/go-redisproto"
   packages = ["."]
   revision = "14323b204640af1628764b06726c64fe040998e1"
@@ -27,6 +33,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e921d588bb6f8afc166c55654355ba40ed7babec664ff37d87476d6ba76d4e44"
+  inputs-digest = "9db747fd00718ac51a727f7091577219d4adaac6d7e55d9a2fc4974affcbeed3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,3 +10,6 @@
   name = "github.com/secmask/go-redisproto"
   revision = "14323b204640af1628764b06726c64fe040998e1"
 
+[[constraint]]
+  name = "github.com/go-redis/redis"
+  version = "6.5.3"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ build: vet fmt test
 	go build
 
 test:
+	go test
 	test/end-to-end -v
 
 lint:

--- a/README.md
+++ b/README.md
@@ -186,16 +186,20 @@ $ dep ensure
 ```
 
 
-Building (also run tests and performs various static checks):
+Running the Go tests:
+```shell
+$ go test
+```
+
+We also have end-to-end tests that run via Docker. Refer
+[here](test/README.md) for more information.
+
+
+Run tests (must have done `make spawn` before), perform various static checks
+and finally build the project:
 ```shell
 $ make
 ```
-
-Running the tests:
-```shell
-$ make test
-```
-(Refer [here](test/README.md) for more information on testing Rafka).
 
 List all available commands:
 ```shell

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Example using Redis:
 ### Consumer
 - `CLIENT SETNAME <group.id>:<name>`: sets the consumer's group & name
 - `CLIENT GETNAME`
-- `BLPOP topics:<topic> <timeoutMs>`: consumes the next message from <topic>
+- `BLPOP topics:<topic> <timeoutMs>`: consumes the next message from the given topic
 - `RPUSH acks <topic>:<partition>:<offset>`: commit the offset for the given topic/partition
 
 Example using Redis:

--- a/client.go
+++ b/client.go
@@ -43,7 +43,7 @@ func NewClient(conn net.Conn, cm *ConsumerManager) *Client {
 // "<consumer-group>:<consumer-id>".
 func (c *Client) SetID(id string) error {
 	if c.consReady {
-		return errors.New("CLient ID is already set to " + c.id)
+		return errors.New("Client ID is already set to " + c.id)
 	}
 
 	parts := strings.SplitN(id, ":", 2)

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-redis/redis"
+)
+
+func TestSetIDTwice(t *testing.T) {
+	c := redis.NewClient(&redis.Options{
+		Addr: "localhost:6380",
+		OnConnect: func(c *redis.Conn) error {
+			res := c.ClientSetName("foobar:foo2")
+			if res.Err() != nil {
+				t.Fatal(res.Err())
+			}
+
+			if c.ClientSetName("foobar:foo3").Err() == nil {
+				t.Fatal("Expected error, got nothing")
+			}
+			return nil
+		}})
+
+	c.Ping().Result()
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-redis/redis"
@@ -8,7 +9,7 @@ import (
 
 func TestSetIDTwice(t *testing.T) {
 	c := redis.NewClient(&redis.Options{
-		Addr: "localhost:6380",
+		Addr: fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		OnConnect: func(c *redis.Conn) error {
 			res := c.ClientSetName("foobar:foo2")
 			if res.Err() != nil {

--- a/config.go
+++ b/config.go
@@ -4,6 +4,9 @@ import "time"
 import rdkafka "github.com/confluentinc/confluent-kafka-go/kafka"
 
 type Config struct {
+	Host string
+	Port int
+
 	Librdkafka struct {
 		General  rdkafka.ConfigMap `json:"general"`
 		Consumer rdkafka.ConfigMap `json:"consumer"`

--- a/rafka.go
+++ b/rafka.go
@@ -16,7 +16,10 @@ import (
 	"github.com/urfave/cli"
 )
 
-var cfg Config
+var (
+	cfg      Config
+	shutdown = make(chan os.Signal, 1)
+)
 
 func main() {
 	app := cli.NewApp()
@@ -108,8 +111,7 @@ func main() {
 func run(c *cli.Context) {
 	l := log.New(os.Stderr, "[rafka] ", log.Ldate|log.Ltime)
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
 
 	ctx := context.Background()
 
@@ -139,7 +141,7 @@ func run(c *cli.Context) {
 
 	}()
 
-	<-sigCh
+	<-shutdown
 	l.Println("Received shutdown signal. Shutting down...")
 	serverCancel()
 	serverWg.Wait()

--- a/rafka.go
+++ b/rafka.go
@@ -30,6 +30,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "kafka, k",
 			Usage: "Load librdkafka configuration from `FILE`",
+			Value: "kafka.json",
 		},
 		cli.Int64Flag{
 			Name:  "commit-intvl, i",

--- a/rafka_test.go
+++ b/rafka_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis"
+)
+
+func TestMain(m *testing.M) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		main()
+		wg.Done()
+	}()
+
+	result := m.Run()
+	shutdown <- os.Interrupt
+	wg.Wait()
+	os.Exit(result)
+}
+
+// TODO(agis) Move this to an end-to-end test when rafka-rb is able to consume
+// multiple topics from the same client instance.
+func TestConsumerTopicExclusive(t *testing.T) {
+	id := "bar:baz"
+	c := newClient(id)
+	_, err := c.BLPop(1*time.Second, "topics:foo").Result()
+	if err != nil && err != redis.Nil {
+		t.Fatal(err)
+	}
+
+	expErr := "CONS Topic foo has another consumer"
+	_, err = c.BLPop(1*time.Second, "topics:foo,foo2").Result()
+	if err.Error() != expErr {
+		t.Errorf("Expected error: `%s`, was `%s`", expErr, err)
+	}
+
+	err = c.Close()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestErrRPUSHX(t *testing.T) {
+	c := newClient("some:producer")
+
+	_, err := c.RPushX("invalid-arg", "a msg").Result()
+	if err == nil {
+		t.Error("Expected error, got nothing")
+	}
+
+	err = c.Close()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestSETNAME(t *testing.T) {
+	numReq := 100
+	replies := make(chan string)
+
+	expected := 0
+	for i := 0; i < numReq; i++ {
+		expected += i
+		go func(n int) {
+			c := newClient((fmt.Sprintf("foo:bar-%d", n)))
+
+			res, err := c.ClientGetName().Result()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			replies <- res
+
+			err = c.Close()
+			if err != nil {
+				t.Error(err)
+			}
+		}(i)
+	}
+
+	actual := 0
+	for i := 0; i < numReq; i++ {
+		n, err := strconv.Atoi(strings.Split(<-replies, "-")[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual += n
+	}
+
+	if actual != expected {
+		t.Errorf("Expected %d, got %d", expected, actual)
+	}
+}
+
+func newClient(id string) *redis.Client {
+	return redis.NewClient(&redis.Options{
+		Addr:      "localhost:6380",
+		OnConnect: setName(id)})
+}
+
+func setName(id string) func(*redis.Conn) error {
+	return func(c *redis.Conn) error {
+		res := c.ClientSetName(id)
+		if res.Err() != nil {
+			log.Fatalf("%s", res.Err())
+		}
+		return nil
+	}
+}

--- a/rafka_test.go
+++ b/rafka_test.go
@@ -14,12 +14,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	cfg.Port = 6382
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		main()
 		wg.Done()
 	}()
+
+	for newClient("wait:for-rafka").Ping().Val() != "PONG" {
+	}
 
 	result := m.Run()
 	shutdown <- os.Interrupt
@@ -103,7 +108,7 @@ func TestSETNAME(t *testing.T) {
 
 func newClient(id string) *redis.Client {
 	return redis.NewClient(&redis.Options{
-		Addr:      "localhost:6380",
+		Addr:      fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		OnConnect: setName(id)})
 }
 

--- a/server.go
+++ b/server.go
@@ -240,13 +240,12 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 }
 
-func (s *Server) ListenAndServe(port string) error {
-	// TODO(agis): maybe we want to control host through a flag
-	listener, err := net.Listen("tcp", port)
+func (s *Server) ListenAndServe(hostport string) error {
+	listener, err := net.Listen("tcp", hostport)
 	if err != nil {
 		return err
 	}
-	s.log.Print("Listening on 0.0.0.0" + port)
+	s.log.Print("Listening on " + hostport)
 
 	go func() {
 		<-s.ctx.Done() // unblock Accept()

--- a/server.go
+++ b/server.go
@@ -67,7 +67,10 @@ func (s *Server) handleConn(conn net.Conn) {
 		} else {
 			cmd := strings.ToUpper(string(command.Get(0)))
 			switch cmd {
-			case "BLPOP": // consume
+			// Consume the next message from one or more topics
+			//
+			// BLPOP topics:<topic> <timeoutMs>
+			case "BLPOP":
 				topics, err := parseTopics(string(command.Get(1)))
 				if err != nil {
 					writeErr = writer.WriteError("CONS " + err.Error())
@@ -113,7 +116,10 @@ func (s *Server) handleConn(conn net.Conn) {
 					}
 				}
 				ticker.Stop()
-			case "RPUSH": // ack (consumer)
+			// Commit offsets for the given topic/partition
+			//
+			// RPUSH acks <topic>:<partition>:<offset>
+			case "RPUSH":
 				key := strings.ToUpper(string(command.Get(1)))
 				if key != "ACKS" {
 					writeErr = writer.WriteError("CONS You can only RPUSH to the 'acks' key")
@@ -134,7 +140,10 @@ func (s *Server) handleConn(conn net.Conn) {
 
 				cons.SetOffset(topic, partition, offset+1)
 				writeErr = writer.WriteBulkString("OK")
-			case "RPUSHX": // produce
+			// Produce a message
+			//
+			// RPUSHX topics:<topic> <message>
+			case "RPUSHX":
 				argc := command.ArgCount() - 1
 				if argc != 2 {
 					writeErr = writer.WriteError("PROD RPUSHX accepts 2 arguments, got " + strconv.Itoa(argc))
@@ -162,7 +171,10 @@ func (s *Server) handleConn(conn net.Conn) {
 					break
 				}
 				writeErr = writer.WriteInt(1)
-			case "DUMP": // flush (producer)
+			// Flush the producer
+			//
+			// DUMP <timeoutMs>
+			case "DUMP":
 				if c.producer == nil {
 					writeErr = writer.WriteBulkString("OK")
 					break
@@ -183,6 +195,9 @@ func (s *Server) handleConn(conn net.Conn) {
 			case "CLIENT":
 				subcmd := strings.ToUpper(string(command.Get(1)))
 				switch subcmd {
+				// Set the consumer group.id
+				//
+				// CLIENT SETNAME <group.id>:<name>
 				case "SETNAME":
 					prevID := c.id
 					newID := string(command.Get(2))

--- a/server.go
+++ b/server.go
@@ -161,7 +161,7 @@ func (s *Server) handleConn(conn net.Conn) {
 					writeErr = writer.WriteError("PROD " + err.Error())
 					break
 				}
-				writeErr = writer.WriteBulkString("OK")
+				writeErr = writer.WriteInt(1)
 			case "DUMP": // flush (producer)
 				if c.producer == nil {
 					writeErr = writer.WriteBulkString("OK")

--- a/test/README.md
+++ b/test/README.md
@@ -27,6 +27,9 @@ Then start the Rafka container (inside this directory):
 $ docker-compose up
 ```
 
+(Note: Additionally, you can use `make spawn` from the root project directory
+to spin up a rafka server without using docker-compose)
+
 Finally, run the tests:
 ```shell
 $ ./end-to-end

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -234,6 +234,10 @@ puts "\nRunning on #{host_port.join(":")} " \
      "(rafka-rb #{Rafka::VERSION}, CONSUME_RETRIES=#{CONSUME_RETRIES}, " \
      "CONSUME_TIMEOUT=#{CONSUME_TIMEOUT})..."
 
+if Rafka::Producer.new(CLIENT_DEFAULTS).ping != "PONG"
+  abort "Could not PING Rafka server. Is it up?"
+end
+
 $topics = []
 
 MiniTest.after_run do

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -11,7 +11,7 @@ require_relative "test_helper"
 host_port = (ENV["RAFKA"] || "localhost:6380").split(":")
 host, port = host_port[0], Integer(host_port[1])
 
-CLIENT_DEFAULTS = { host: host, port: port }
+CLIENT_DEFAULTS = { host: host, port: port, redis: { reconnect_attempts: 5 } }
 FLUSH_TIMEOUT = 5000
 CONSUME_RETRIES = 3
 CONSUME_TIMEOUT = 1


### PR DESCRIPTION
These test implementation details on a lower level than the end-to-end
tests and have access to APIs that rafka-rb doesn't yet (eg. consuming
multiple topics from the same client).

Closes #13