### PR TITLE
producer: Consume event channel in a goroutine

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -89,9 +89,13 @@ func (p *Producer) consumeDeliveries() {
 	defer p.wg.Done()
 
 	for ev := range p.rdProd.Events() {
-		msg := ev.(*rdkafka.Message)
-		if err := msg.TopicPartition.Error; err != nil {
-			p.log.Printf("Failed to deliver `%s` to %s: %s", msg.Value, msg, err)
+		msg, ok := ev.(*rdkafka.Message)
+		if ok {
+			if err := msg.TopicPartition.Error; err != nil {
+				p.log.Printf("Failed to deliver `%s` to %s: %s", msg.Value, msg, err)
+			}
+		} else {
+			p.log.Printf("Unknown event type: %s", ev)
 		}
 	}
 }


### PR DESCRIPTION
The librdkafka producer events channel should be consumed prior to
calling `Flush()`, otherwise we'll hit the flush timeout and outstanding
events will be reported by `Flush()` (for more info see
https://github.com/confluentinc/confluent-kafka-go/blob/v0.11.0/kafka/producer.go#L195-L215)

Therefore, we have to constantly consume events by the `Events()`
channel until the producer is `Close()`ed, therefore its events channel
is closed. We introduced a new goroutine, `consumeDeliveries` that does
just that, consumes events and logs any failures.

Some refactorings were also performed:

- `run()` is no longer a separate method/goroutine but is embedded in `Close()`
instead. This simplifies the Producer's internals.
- Use a sync.WaitGroup instead of close/done channels

Fixes #33