### PR TITLE
	Make Client responsible for closing its conn

### DIFF
--- a/client.go
+++ b/client.go
@@ -132,8 +132,8 @@ func (c *Client) Producer(cfg *rdkafka.ConfigMap) (*Producer, error) {
 	return c.producer, nil
 }
 
-// Close closes c's underlying producers and consumers. Calling Close on
-// an already closed client will result in a panic.
+// Close closes producers, consumers and the connection of c.
+// Calling Close on an already closed client will result in a panic.
 func (c *Client) Close() {
 	for cid := range c.consumers {
 		// TODO(agis): make this blocking
@@ -143,4 +143,6 @@ func (c *Client) Close() {
 	if c.producer != nil {
 		c.producer.Close()
 	}
+
+	c.conn.Close()
 }

--- a/server.go
+++ b/server.go
@@ -55,10 +55,9 @@ func NewServer(ctx context.Context, manager *ConsumerManager, timeout time.Durat
 }
 
 func (s *Server) handleConn(conn net.Conn) {
-	defer conn.Close()
-
 	c := NewClient(conn, s.manager)
 	defer c.Close()
+
 	s.clientByID.Store(c.id, c)
 	defer func() {
 		s.clientByID.Delete(c.id)


### PR DESCRIPTION
Prior to this, closing the client's connection was done as a separate
step, outside of `client.Close()`. Making this the job of `Client`,
which already knows about its underlying connection, makes sense
considering that `Client` is a higher-level abstraction that includes
a connection in its internal state.

This keeps the order of the closing sequence the same as before: first
consumers/producers are closed and then the underlying client connection
is closed (deferred functions are executed in a LIFO manner).

Closes #36.