### PR TITLE
Add support for message keys in the producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ API
 ------------------------------------------------------------------------------
 
 ### Producer
-- `RPUSHX topics:<topic> <message>`: produce a message
+- `RPUSHX topics:<topic> <message>`: produce a message. The message will be assigned to a random partition.
+- `RPUSHX topics:<topic>:<key> <message>`: produce a message with a key. Two or more messages with the same key will always be assigned to the same partition.
 - `DUMP <timeoutMs>`: flushes the messages to Kafka. This is a blocking operation, it returns until all buffered messages are flushed or the timeout exceeds
 
 Example using Redis:

--- a/rafka_test.go
+++ b/rafka_test.go
@@ -100,6 +100,20 @@ func TestProduceErr(t *testing.T) {
 	}
 }
 
+func TestProduceWithKey(t *testing.T) {
+	c := newClient("some:producer")
+
+	_, err := c.RPushX("topic:foo:bar", "a msg").Result()
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = c.Close()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 // SETNAME
 func TestClientID(t *testing.T) {
 	numReq := 100

--- a/server.go
+++ b/server.go
@@ -189,13 +189,18 @@ func (s *Server) handleConn(conn net.Conn) {
 				}
 
 				parts := bytes.Split(command.Get(1), []byte(":"))
-				if len(parts) != 2 {
-					writeErr = writer.WriteError("PROD First argument must be in the form of 'topics:<topic>'")
+				if len(parts) != 2 && len(parts) != 3 {
+					errMsg := "PROD First argument must be in the form of 'topics:<topic>' or 'topics:<topic>:<key>'"
+					writeErr = writer.WriteError(errMsg)
 					break
 				}
 				topic := string(parts[1])
 				tp := rdkafka.TopicPartition{Topic: &topic, Partition: rdkafka.PartitionAny}
 				kafkaMsg := &rdkafka.Message{TopicPartition: tp, Value: command.Get(2)}
+
+				if len(parts) == 3 {
+					kafkaMsg.Key = parts[2]
+				}
 
 				prod, err := c.Producer(cfg.Librdkafka.Producer)
 				if err != nil {

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/skroutz/rafka-rb
-  revision: 9a190e41e07b5632d7f6b861419b21690a6195a8
+  revision: f197fc6924c2588e87c5c1523fd642cd6507fd36
   specs:
-    rafka (0.0.8)
+    rafka (0.0.9)
       redis (~> 3.0)
 
 GEM

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -16,4 +16,4 @@ services:
 networks:
   default:
     external:
-      name: kafkacluster_default
+      name: kafkaclustertestbed_default

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -39,6 +39,24 @@ class TestRafka < Minitest::Test
     end
   end
 
+  def test_produce_with_key
+    with_new_topic(consumer: true) do |topic, cons|
+      start_consumer!(cons)
+
+      100.times { |i| @prod.produce(topic, i, key: 'foo') }
+      assert_flushed @prod
+
+      partitions = []
+      100.times do |i|
+        msg = consume_with_retry(cons)
+        assert_rafka_msg msg
+        partitions << msg.partition
+      end
+
+      assert_equal 1, partitions.uniq.size
+    end
+  end
+
   def test_many_consumers_same_topic
     with_new_topic do |topic|
       gid = rand_id


### PR DESCRIPTION
Two or more messages with the same key will always be assigned to the
same kafka partition.

This feature will enable us to guarantee a consistent message
consumption order.