### PR TITLE
Add test for manual offset management in rafka-rb

### DIFF
--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/skroutz/rafka-rb
-  revision: c3842497921243f47d45aa91cbb5c4df96d9bef0
+  revision: ce1c2bb0d5f47bb6f4bbaabf4f3ba13f0be968f2
   specs:
     rafka (0.0.10)
       redis (~> 3.0)

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/skroutz/rafka-rb
-  revision: 03893c3312d940090b1b7a8de7e17a5f08668e1f
+  revision: c3842497921243f47d45aa91cbb5c4df96d9bef0
   specs:
-    rafka (0.0.9)
+    rafka (0.0.10)
       redis (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.11.1)
+    minitest (5.11.3)
     redis (3.0.3)
 
 PLATFORMS

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -263,6 +263,69 @@ class TestRafka < Minitest::Test
     @prod.redis.del("stats")
     assert @prod.redis.hgetall("stats")["producer.delivery.errors"], "0"
   end
+
+  def test_consumer_manual_commit
+    with_new_topic(consumer: true, partitions: 2) do |topic|
+      n = 50
+      abort "n (#{n}) must be an even number" if n.odd?
+
+      gid = rand_id
+
+      cons = Rafka::Consumer.new(CLIENT_DEFAULTS.merge(
+        topic: topic, group: gid, id: "a", auto_commit: false))
+      start_consumer!(cons)
+
+      n.times { |i| @prod.produce(topic, i) }
+      assert_flushed @prod
+
+      partition_offsets = Hash.new(0)
+      msg = nil
+
+      # do a plain consume of all messages, without committing offsets
+      n.times do
+        msg = consume_with_retry(cons)
+        assert_rafka_msg(msg)
+        partition_offsets[msg.partition] = msg.offset
+      end
+
+      # restart consumer; we should start without any initial offsets since
+      # we didn't commit
+      cons.close
+      msg = consume_with_retry(cons)
+      assert_equal 0, msg.offset
+      cons.close
+
+      # restart and consume again; this time commit offsets
+      partition_msgs = {}
+      n.times do
+        msg = consume_with_retry(cons)
+        assert_rafka_msg(msg)
+        partition_offsets[msg.partition] = msg.offset
+        partition_msgs[msg.partition] = msg
+      end
+      res = cons.commit(*partition_msgs.values)
+      assert_equal n, res[topic].values.inject(:+)+2
+
+      # restart and consume; we should start with the previous offsets since
+      # we did commit. We check every partition we previously had committed
+      # for.
+      checked_partitions = {}
+      cons.close
+
+      n.times { |i| @prod.produce(topic, i) }
+      assert_flushed @prod
+
+      while checked_partitions.keys.sort != partition_offsets.keys.sort
+        msg = consume_with_retry(cons)
+        assert_rafka_msg(msg)
+        next if checked_partitions[msg.partition]
+        assert_equal partition_offsets[msg.partition], msg.offset-1
+        checked_partitions[msg.partition] = true
+      end
+
+      cons.close
+    end
+  end
 end
 
 puts "\nRunning on #{host_port.join(":")} " \


### PR DESCRIPTION
This is a follow-up to https://github.com/skroutz/rafka-rb/pull/9.