### PR TITLE
Add end-to-end test for batch consuming

### DIFF
--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/skroutz/rafka-rb
-  revision: ce1c2bb0d5f47bb6f4bbaabf4f3ba13f0be968f2
+  revision: 690772123611a7d6dce12a3d1d0d805fde10e305
   specs:
-    rafka (0.0.10)
+    rafka (0.2.2)
       redis (~> 3.0)
 
 GEM

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -13,7 +13,7 @@ host, port = host_port[0], Integer(host_port[1])
 
 CLIENT_DEFAULTS = { host: host, port: port, redis: { reconnect_attempts: 5 } }
 FLUSH_TIMEOUT = 5000
-CONSUME_RETRIES = 3
+CONSUME_RETRIES = 1
 CONSUME_TIMEOUT = 1
 
 class TestRafka < Minitest::Test

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -321,6 +321,103 @@ class TestRafka < Minitest::Test
       cons.close
     end
   end
+
+  def test_consumer_batch
+    with_new_topic(consumer: true) do |topic, cons|
+      50.times { |i| @prod.produce(topic, i) }
+      assert_flushed @prod
+
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 30, batching_max_sec: 5)
+      assert_equal 30, msgs.size
+
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 9999, batching_max_sec: 2)
+      assert_equal 20, msgs.size
+
+      50.times { |i| @prod.produce(topic, i) }
+      assert_flushed @prod
+
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 30, batching_max_sec: 0)
+      assert_equal 30, msgs.size
+
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 0, batching_max_sec: 2)
+      assert_equal 20, msgs.size
+    end
+  end
+
+  def test_consumer_batch_commit
+    with_new_topic(consumer: true, partitions: 1) do |topic, cons|
+      50.times { |i| @prod.produce(topic, i) }
+      assert_flushed @prod
+
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 10)
+      msgs.map! { |m| Integer(m.value) }.sort!
+      assert_equal 9, msgs.last
+
+      # close and re-consume; we should start from the previous point
+      cons.close
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 5)
+      msgs.map! { |m| Integer(m.value) }.sort!
+      assert_equal 14, msgs.last
+
+
+      assert_raises RuntimeError do
+        # close and re-consume with a block; we should start from the previous
+        # point
+        cons.close
+        cons.consume_batch(timeout: 0.3, batch_size: 5) do |msgs|
+          results = msgs.map { |m| Integer(m.value) }.sort
+          assert_equal 19, results.last
+
+          # raise an error to avoid committing the offsets
+          raise "foo"
+        end
+      end
+
+      # close and re-consume; we should get again the same messages since
+      # the previous consume didn't commit offsets
+      cons.close
+      msgs = cons.consume_batch(timeout: 0.3, batch_size: 5)
+      msgs.map! { |m| Integer(m.value) }.sort!
+      assert_equal 19, msgs.last
+    end
+  end
+
+  def test_consume_with_block
+    with_new_topic(consumer: true, partitions: 1) do |topic, cons|
+      10.times { |i| @prod.produce(topic, i) }
+      assert_flushed @prod
+
+      msg = nil
+
+      assert_rafka_msg(cons.consume)
+      cons.consume do |msg|
+        assert_equal 1, Integer(msg.value)
+      end
+
+      # close and restart; we should continue from where we left
+      cons.close
+      cons.consume do |msg|
+        assert_equal 2, Integer(msg.value)
+      end
+
+      # consume with a block that raises an error; offsets shouldn't be
+      # committed
+      cons.close
+      assert_raises RuntimeError do
+        cons.consume do |msg|
+          assert_equal 3, Integer(msg.value)
+
+          # raise an error to avoid committing the offsets
+          raise "foo"
+        end
+      end
+
+      # close and re-consume; we should start again from the already consumed
+      # messages b/c offsets weren't committed
+      cons.close
+      assert_equal 3, Integer(cons.consume.value)
+    end
+  end
 end
 
 puts "\nRunning on #{host_port.join(":")} " \


### PR DESCRIPTION
This feature was added in rafka-rb 0.2.0 (https://github.com/skroutz/rafka-rb/pull/12).