### PR TITLE
Use librdkafka auto commit and store offsets functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Usage
 
 ```shell
 $ vim kafka.json.sample # Add brokers
-$ go build && ./rafka -k ./kafka.json.sample -i 10
+$ go build && ./rafka -k ./kafka.json.sample
 ```
 
 

--- a/config.go
+++ b/config.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"time"
-
 	rdkafka "github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
@@ -29,6 +27,4 @@ type Config struct {
 		Consumer rdkafka.ConfigMap `json:"consumer"`
 		Producer rdkafka.ConfigMap `json:"producer"`
 	}
-
-	CommitIntvl time.Duration
 }

--- a/consumer_manager.go
+++ b/consumer_manager.go
@@ -87,7 +87,7 @@ func (m *ConsumerManager) GetOrCreate(cid ConsumerID, gid string, topics []strin
 			m.log.Printf("Error configuring consumer: %s", err)
 		}
 
-		c := NewConsumer(string(cid), topics, m.cfg.CommitIntvl, kafkaCfg)
+		c := NewConsumer(string(cid), topics, kafkaCfg)
 		ctx, cancel := context.WithCancel(m.ctx)
 		m.pool[cid] = &consumerPoolEntry{
 			consumer: c,

--- a/kafka.json.sample
+++ b/kafka.json.sample
@@ -8,7 +8,9 @@
  "consumer": {
    "go.events.channel.enable": false,
    "go.application.rebalance.enable": false,
-   "enable.auto.commit": false,
+   "enable.auto.commit": true,
+   "auto.commit.interval.ms": 10000,
+   "enable.auto.offset.store": false,
    "auto.offset.reset": "latest",
    "enable.partition.eof": false
  },

--- a/rafka.go
+++ b/rafka.go
@@ -60,11 +60,6 @@ func main() {
 			Usage: "Load librdkafka configuration from `FILE`",
 			Value: "kafka.json",
 		},
-		cli.Int64Flag{
-			Name:  "commit-intvl, i",
-			Usage: "Commit offsets of each consumer every `N` seconds",
-			Value: 10,
-		},
 	}
 
 	app.Before = func(c *cli.Context) error {
@@ -84,11 +79,6 @@ func main() {
 		if err != nil {
 			return err
 		}
-
-		if c.Int64("commit-intvl") <= 0 {
-			return errors.New("`commit-intvl` option must be greater than 0")
-		}
-		cfg.CommitIntvl = time.Duration(c.Int64("commit-intvl"))
 
 		// cfg might be set before main() runs (eg. while testing)
 		if cfg.Host == "" {

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -29,4 +29,4 @@ WORKDIR "/rafka"
 ENTRYPOINT ["test/docker-entrypoint.sh"]
 EXPOSE 6380
 
-CMD ["-k", "test/kafka.test.json", "-i", "1"]
+CMD ["-k", "test/kafka.test.json"]

--- a/test/kafka.test.json
+++ b/test/kafka.test.json
@@ -9,7 +9,9 @@
  "consumer": {
    "go.events.channel.enable": false,
    "go.application.rebalance.enable": false,
-   "enable.auto.commit": false,
+   "enable.auto.commit": true,
+   "auto.commit.interval.ms": 1000,
+   "enable.auto.offset.store": false,
    "auto.offset.reset": "earliest",
    "enable.partition.eof": false
  },


### PR DESCRIPTION
* `Consumer.SetOffset()` uses the new `rdkafka.Consumer.StoreOffsets()`, which will store the offsets (related to the consumer config `enable.auto.offset.store: false`)
* the client no longer runs the periodic `c.commitOffsets()` loop. The goroutine and its relevant synchronization were completely removed. This is replaced with the `enable.auto.commit: true` consumer config.
* `Consumer.Run()` now after subscribing to the topics just waits for the `ctx.Done()`
* the `-i` flag is removed, replaced by the consumer config `auto.commit.interval.ms`

Closes #32 