### PR TITLE
Print information of committed offsets

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -82,12 +82,15 @@ func (c *Consumer) Poll(timeoutMS int) (*rdkafka.Message, error) {
 	switch e := ev.(type) {
 	case *rdkafka.Message:
 		return e, nil
+	case rdkafka.OffsetsCommitted:
+		c.log.Print(e)
 	case rdkafka.Error:
 		return nil, errors.New(e.String())
 	default:
 		c.log.Printf("Unknown event type: %T", e)
-		return nil, nil
 	}
+
+	return nil, nil
 }
 
 // SetOffset sets the offset for the given topic and partition to pos.


### PR DESCRIPTION
With this change, log lines like the following:

    Unknown event type: kafka.OffsetsCommitted

now become:

    OffsetsCommitted (<nil>, [r-0bc221[0]@unset r-0bc221[1]@1 r-0bc221[2]@unset r-0bc221[3]@unset])

This particular line means that there were no error committing offsets
(<nil>) on that in the foo topic, we committed the
offset 7 for partition 0 and no offset for partition 1.

This is a follow-up to ffe8e40.