### PR TITLE
server: Add support for KEYS cmd to list topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Example using Redis:
 - [`QUIT`](https://redis.io/commands/quit)
 - `HGETALL stats`: returns a hash with various statistics useful for
   monitoring.
+- `KEYS topics:`: list all topics
 - `DEL stats`: resets the monitoring statistics.
 
 

--- a/main_test.go
+++ b/main_test.go
@@ -265,6 +265,16 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+// KEYS
+func TestMetadataQuery(t *testing.T) {
+	c := newClient("someone:random_producer")
+
+	_, err := c.Keys("topics:").Result()
+	if err != nil {
+		t.Errorf("Could not execute KEYS command: `%s`", err)
+	}
+}
+
 func newClient(id string) *redis.Client {
 	return redis.NewClient(&redis.Options{
 		// TODO Add the ability to read host and port from a cfg file

--- a/server.go
+++ b/server.go
@@ -139,6 +139,40 @@ func (s *Server) Handle(ctx context.Context, conn net.Conn) {
 					break
 				}
 				writeErr = writer.WriteObjects(stats.toRedis()...)
+			// List all topics
+			//
+			// KEYS
+			case "KEYS":
+				arg1 := string(command.Get(1))
+				if arg1 != "topics:" {
+					writeErr = writer.WriteError("ERR Expected argument to be 'topics:', got " + arg1)
+					break
+				}
+
+				prod, err := c.Producer(cfg.Librdkafka.Producer)
+				if err != nil {
+					writeErr = writer.WriteError("ERR Error spawning producer: " + err.Error())
+					break
+				}
+
+				metadata, err := prod.rdProd.GetMetadata(nil, true, 100)
+				if err != nil {
+					writeErr = writer.WriteError("ERR Error getting metadata: " + err.Error())
+					break
+				}
+
+				var topic_names []interface{}
+
+				for topic_name, _ := range metadata.Topics {
+					topic_names = append(topic_names, "topics:"+topic_name)
+				}
+
+				if len(topic_names) > 0 {
+					writeErr = writer.WriteObjects(topic_names...)
+				} else {
+					// we need to return empty array here
+					_, writeErr = writer.Write([]byte{'*', '0', '\r', '\n'})
+				}
 			// Reset producer/consumer statistics
 			//
 			// DEL stats

--- a/server.go
+++ b/server.go
@@ -304,7 +304,7 @@ func (s *Server) Handle(ctx context.Context, conn net.Conn) {
 				writer.Flush()
 				return
 			case "PING":
-				writeErr = writer.WriteBulkString("PONG")
+				writeErr = writer.WriteSimpleString("PONG")
 			default:
 				writeErr = writer.WriteError("Command not supported")
 			}


### PR DESCRIPTION
This commit adds a new cmd in the likes of the redis [KEYS](https://redis.io/commands/keys) command.
It is used to list all the topics of the cluster in their fully qualified names.

Note: Normal redis `KEYS` command takes one argument which matches
it as a glob against all keyspace. We do indeed accept an argument for
the sake of compatibility but we ignore it.

Usage example:
```
localhost:6380> keys topics:
1) "topics:greetings"
2) "topics:__consumer_offsets"
3) "topics:another-topic"
```