### PR TITLE
Shutdown revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vimrc
 *dump.rdb
+core
 librdkafka.json
 rafka
 test/.bundle

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ for more information.
 
 
 
-Dependencies
+Requirements
 -------------------------------------------------------------------------------
-- [Go 1.9 or later](https://golang.org/)
+
 - [librdkafka 0.11.0 or later](https://github.com/edenhill/librdkafka)
-- for the rest see `Gopkg.toml`
+- A Kafka cluster
 
 
 

--- a/client.go
+++ b/client.go
@@ -43,6 +43,7 @@ type Client struct {
 // should be closed with Close().
 func NewClient(conn net.Conn, cm *ConsumerManager) *Client {
 	id := conn.RemoteAddr().String()
+
 	return &Client{
 		id:          id,
 		conn:        conn,
@@ -53,8 +54,8 @@ func NewClient(conn net.Conn, cm *ConsumerManager) *Client {
 	}
 }
 
-// SetID sets the id for c. It returns an error if id is not in the form
-// "<consumer-group>:<consumer-id>".
+// SetID sets the id for c. It returns an error if id is not in the form of
+// <consumer-group>:<consumer-id>.
 func (c *Client) SetID(id string) error {
 	if c.consReady {
 		return errors.New("Client ID is already set to " + c.id)
@@ -64,9 +65,10 @@ func (c *Client) SetID(id string) error {
 	if len(parts) != 2 {
 		return errors.New("Cannot parse group.id")
 	}
+
 	c.id = id
 	c.consGID = parts[0]
-	c.log.SetPrefix(fmt.Sprintf("[client-%s] ", id))
+	c.log.SetPrefix(fmt.Sprintf("[client-%s] ", c.id))
 	c.consReady = true
 	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package main
+
+import "errors"
+
+var ErrShutdown = errors.New("shutdown")

--- a/server.go
+++ b/server.go
@@ -36,8 +36,12 @@ import (
 )
 
 type Server struct {
-	log     *log.Logger
-	manager *ConsumerManager
+	log      *log.Logger
+	listener net.Listener
+
+	manager       *ConsumerManager
+	managerCancel func()
+	managerWg     sync.WaitGroup
 
 	// default timeout for consumer poll
 	timeout time.Duration
@@ -46,9 +50,8 @@ type Server struct {
 	clientByID sync.Map // map[string]*Client
 }
 
-func NewServer(manager *ConsumerManager, timeout time.Duration) *Server {
+func NewServer(timeout time.Duration) *Server {
 	return &Server{
-		manager: manager,
 		timeout: timeout,
 		log:     log.New(os.Stderr, "[server] ", log.Ldate|log.Ltime),
 	}
@@ -273,7 +276,7 @@ func (s *Server) Handle(ctx context.Context, conn net.Conn) {
 			case "CLIENT":
 				subcmd := strings.ToUpper(string(command.Get(1)))
 				switch subcmd {
-				// Set the consumer group.id
+				// Set the consumer group.id and name
 				//
 				// CLIENT SETNAME <group.id>:<name>
 				case "SETNAME":
@@ -294,8 +297,9 @@ func (s *Server) Handle(ctx context.Context, conn net.Conn) {
 					s.clientByID.Store(newID, c)
 					s.clientByID.Delete(prevID)
 					writeErr = writer.WriteBulkString("OK")
+				// Get the consumer group.id and name
 				case "GETNAME":
-					writeErr = writer.WriteBulkString(c.String())
+					writeErr = writer.WriteBulkString(c.id)
 				default:
 					writeErr = writer.WriteError("CONS Command not supported")
 				}
@@ -320,33 +324,30 @@ func (s *Server) Handle(ctx context.Context, conn net.Conn) {
 }
 
 func (s *Server) ListenAndServe(ctx context.Context, hostport string) error {
-	var inflightWg sync.WaitGroup
+	var wg, inflightWg sync.WaitGroup
+	var err error
 
-	listener, err := net.Listen("tcp", hostport)
+	managerCtx, managerCancel := context.WithCancel(ctx)
+	s.manager = NewConsumerManager(managerCtx, cfg)
+	s.managerCancel = managerCancel
+
+	s.managerWg.Add(1)
+	go func() {
+		defer s.managerWg.Done()
+		s.manager.Run()
+	}()
+
+	s.listener, err = net.Listen("tcp", hostport)
 	if err != nil {
 		return err
 	}
 	s.log.Print("Listening on " + hostport)
 
+	wg.Add(1)
 	go func() {
-		<-ctx.Done() // unblock Accept()
-		listener.Close()
-
-		closeFunc := func(id, client interface{}) bool {
-			c, ok := client.(*Client)
-			if !ok {
-				s.log.Printf("Couldn't convert %#v to Client", c)
-				return false
-			}
-			// This ugliness is due to the go-redisproto parser's
-			// not having a selectable channel for reading input.
-			// We're stuck with blocking on ReadCommand() and
-			// unblocking it by closing the client's connection.
-			c.conn.Close()
-			s.clientByID.Delete(c.id)
-			return true
-		}
-		s.clientByID.Range(closeFunc)
+		defer wg.Done()
+		<-ctx.Done()
+		s.shutdown()
 	}()
 
 Loop:
@@ -355,7 +356,7 @@ Loop:
 		case <-ctx.Done():
 			break Loop
 		default:
-			conn, err := listener.Accept()
+			conn, err := s.listener.Accept()
 			if err != nil {
 				// we know that closing a listener that blocks
 				// on Accept() will return this error
@@ -372,10 +373,61 @@ Loop:
 		}
 	}
 
-	s.log.Println("Waiting for in-flight connections...")
+	wg.Wait()
 	inflightWg.Wait()
-	s.log.Println("Bye")
 	return nil
+}
+
+// shutdown closes current clients and also stops accepting new clients in a
+// non-blocking manner
+func (s *Server) shutdown() {
+	s.manager.StopAcceptingConsumers()
+	s.managerCancel()
+
+	// Close clients with at least 1 consumer. These clients may have
+	// producers too, but we assume that they are non-critical so we close
+	// them at this point too, which is earlier than the others (see below).
+	s.clientByID.Range(func(id, client interface{}) bool {
+		c, ok := client.(*Client)
+		if !ok {
+			s.log.Printf("Couldn't convert %#v to Client", c)
+			return false
+		}
+
+		if len(c.consumers) > 0 {
+			// This ugliness is due to the go-redisproto parser's
+			// not having a selectable channel for reading input.
+			// We're stuck with blocking on ReadCommand() and
+			// unblocking it by closing the client's connection.
+			c.conn.Close()
+		}
+
+		return true
+	})
+
+	// wait for consumers to actually close
+	s.managerWg.Wait()
+
+	// stop accepting new clients and unblock Accept()
+	err := s.listener.Close()
+	if err != nil {
+		log.Printf("error closing listener: %s", err)
+	}
+
+	// close the rest of the clients (ie. those that have only producers).
+	s.clientByID.Range(func(id, client interface{}) bool {
+		c, ok := client.(*Client)
+		if !ok {
+			s.log.Printf("Couldn't convert %#v to Client", c)
+			return false
+		}
+		// This ugliness is due to the go-redisproto parser's
+		// not having a selectable channel for reading input.
+		// We're stuck with blocking on ReadCommand() and
+		// unblocking it by closing the client's connection.
+		c.conn.Close()
+		return true
+	})
 }
 
 // parseTopicsAndConfig parses the "topics:topic1,topic2:{config}" into

--- a/test/end-to-end
+++ b/test/end-to-end
@@ -461,10 +461,16 @@ puts "\nRunning on #{host_port.join(":")} " \
 
 retries = 0
 rafka_up = false
+
 while retries < 4 && !rafka_up
   retries += 1
-  rafka_up = Rafka::Producer.new(CLIENT_DEFAULTS).ping == "PONG"
-  sleep 1
+
+  begin
+    rafka_up = Rafka::Producer.new(CLIENT_DEFAULTS).ping == "PONG"
+  rescue => Redis::CannotConnectError
+    rafka_up = false
+    sleep 1
+  end
 end
 
 abort "Could not PING Rafka server. Is it up?" if !rafka_up


### PR DESCRIPTION
This patch aims to minimize the downtime for producers and make the
shutdown process generally more robust. The flow is now the following:

1) shutdown signal is received
2) manager: stop accepting new consumers and close existing consumers
3) server: stop accepting new producers and close existing producers
5) shutdown and restart

This way, producer downtime is reduced to the time elapsed between (3)
and (5), which should be less than a second. Nevertheless, clients
should still have sane retry defaults configured anyway, because some
downtime will still occur.

Also added a hard timeout of 5 seconds around the shutdown process.
