### PR TITLE
dont log librdkafka messages in tests

### DIFF
--- a/test/librdkafka.test.json
+++ b/test/librdkafka.test.json
@@ -4,7 +4,8 @@
    "bootstrap.servers": "kc1.docker,kc2.docker",
    "session.timeout.ms": 2000,
    "log.connection.close": false,
-   "heartbeat.interval.ms": 500
+   "heartbeat.interval.ms": 500,
+   "log_level": 0
  },
  "consumer": {
    "go.events.channel.enable": false,


### PR DESCRIPTION
Completely remove librdkafka log output in test invocations, to reduce log clutter when running tests locally and in travis