### PR TITLE
Drop support for librdkafka 0.11.4 and before

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,8 @@
 [[projects]]
   name = "github.com/confluentinc/confluent-kafka-go"
   packages = ["kafka"]
-  revision = "5e4d04e05fc319ce5996a867aafef29059f26862"
-  version = "v0.11.4"
+  revision = "460e8e43b282a1a68219df600ef63442b81faf5f"
+  version = "v0.11.6"
 
 [[projects]]
   name = "github.com/go-redis/redis"
@@ -33,6 +33,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cfe03ee098cc6aab25431931f69fee28a5db8efd013c910449fa6cf12aca7f45"
+  inputs-digest = "b731e47c90c1ef552af3fedbf2e9bd578fa77c9925781c83042ed47bbec9f2f0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/confluentinc/confluent-kafka-go"
-  version = "^0.11.4"
+  version = "=0.11.6"
 
 [[constraint]]
   name = "github.com/urfave/cli"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ for more background and how rafka is used in a production environment.
 Requirements
 -------------------------------------------------------------------------------
 
-- [librdkafka 0.11.0 or later](https://github.com/edenhill/librdkafka)
+- [librdkafka](https://github.com/edenhill/librdkafka) 0.11.5 or later
 - A Kafka cluster
 
 


### PR DESCRIPTION
This enables us to revert the workaround introduced in #61, which was
needed because of confluentinc/confluent-kafka-go#189.

That bug is fixed in librdkafka 0.11.5.

We also bump confluent-kafka-go to 1.0.0, which works with 0.11.5,
0.11.6 and 1.0.0.