### PR TITLE
cons: Don't execute Poll & shutdown concurrently

### DIFF
--- a/server.go
+++ b/server.go
@@ -129,6 +129,10 @@ func (s *Server) Handle(ctx context.Context, conn net.Conn) {
 						writeErr = writer.WriteBulkStrings(nil)
 						break ConsLoop
 					default:
+						// we set a small timeout since
+						// Poll holds a lock that
+						// prevents the consumer to
+						// terminate until Poll returns
 						ev, err := cons.Poll(100)
 						if err != nil {
 							writeErr = writer.WriteError("CONS Poll " + err.Error())


### PR DESCRIPTION
In librdkafka/confluent-kafka-go we shouldn't call Poll() concurrently with
Close() or Unsubscribe(), since that might lead to race conditions. We
noticed such an issue when upgrading to librdkafka 0.11.6 and 1.0.0,
where consumers would block in Poll() forever if rafka attempted to shutdown
right in the middle of a call to Poll() (i.e. clients calling BLPOP). See
edenhill/librdkafka#2333 for background.

This patch synchronizes access between a consumer's Poll() and its
shutdown sequence, so that the two may never run concurrently.
Furthermore, if a consumer is terminated then calling Poll() will
immediately return nil without communicating with Kafka at all.

Fixes consumers blocking on Poll() when the server is shutting down,
with librdkafka 0.11.6 and 1.0.0.