### PR TITLE
consumer: Drop invalid offsets from OffsetsCommitted output

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -83,6 +83,17 @@ func (c *Consumer) Run(ctx context.Context) {
 	c.log.Println("Bye")
 }
 
+// filterOutInvalidOffsets filters out any Offsets of type OffsetInvalid from the given OffsetsCommitted argument.
+func filterOutInvalidOffsets(offsets rdkafka.OffsetsCommitted) rdkafka.OffsetsCommitted {
+	updatedParts := []rdkafka.TopicPartition{}
+	for _, part := range offsets.Offsets {
+		if part.Offset != rdkafka.OffsetInvalid {
+			updatedParts = append(updatedParts, part)
+		}
+	}
+	return rdkafka.OffsetsCommitted{offsets.Error, updatedParts}
+}
+
 func (c *Consumer) Poll(timeoutMS int) (*rdkafka.Message, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -100,7 +111,7 @@ func (c *Consumer) Poll(timeoutMS int) (*rdkafka.Message, error) {
 	case *rdkafka.Message:
 		return e, nil
 	case rdkafka.OffsetsCommitted:
-		c.log.Print(e)
+		c.log.Print(filterOutInvalidOffsets(e))
 	case rdkafka.Error:
 		// Treat errors with error code ErrTransport as transient And just log them.
 		// For now all other errors cause a failure.


### PR DESCRIPTION
When a Rafka consumer receives an `OffsetsCommitted` event it will log an array with information about the commited offsets. This array contains information about all partition/offset pairs in which the Rafka consumer has been subscribed to, regardless of the amount of data that have been actually commited by librdkafka.

For example, consider a topic with _12_ partitions; the `OffsetsCommitted` event of a single partition/offset pair (_part: 9_, _offset: 1_), looks like the following snippet:

```
[cgroup|cid|topic] 2019/08/02 13:43:36 OffsetsCommitted (<nil>, [topic[0]@unset topic[1]@unset topic[2]@unset topic[3]@unset topic[4]@unset topic[5]@unset topic[6]@unset topic[7]@unset topic[8]@unset topic[9]@1 topic[10]@unset topic[11]@unset])
```

This extraneous information makes debugging quite difficult; we actually interested in the updated partitions and not about the unaffected ones.

This commit introduces a new utility named `dropInvalidOffsets` which will be used to trim the _"unset"_ offsets (aka those of `OffsetInvalid` type) from the logging output.

The logging ouput of the `OffsetsCommitted` event for the aforementioned example will be simplified as presented below:

```
[cgroup|cid|topic] 2019/08/02 13:42:20 OffsetsCommitted (<nil>, [topic[9]@1])
```