### PR TITLE
Add support for the MONITOR command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Example using redis-cli:
 
 - [`PING`](https://redis.io/commands/ping)
 - [`QUIT`](https://redis.io/commands/quit)
+- [`MONITOR`](https://redis.io/commands/monitor)
 - `HGETALL stats` get monitoring statistics monitoring
 - `KEYS topics:` list all topics
 - `DEL stats` reset the monitoring statistics

--- a/README.md
+++ b/README.md
@@ -1,111 +1,97 @@
 rafka
-==============================
+=====
+
 [![Build Status](https://api.travis-ci.org/skroutz/rafka.svg?branch=master)](https://travis-ci.org/skroutz/rafka)
 [![Go report](https://goreportcard.com/badge/github.com/skroutz/rafka)](https://goreportcard.com/report/github.com/skroutz/rafka)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 rafka is a gateway service that exposes Kafka using simple semantics.
 
-It implements a small subset of the [Redis protocol](https://redis.io/topics/protocol),
-so that it can be used by leveraging existing Redis client libraries.
-
-
-
-
+It implements a small subset of the [Redis protocol](https://redis.io/topics/protocol), so that it
+can be used by leveraging existing Redis client libraries.
 
 Rationale
--------------------------------------------------------------------------------
-Using Kafka with languages that lack a reliable, solid client library can be a
-problem for mission-critical applications.
+---------
+
+Using Kafka with languages that lack a reliable, solid client library can be a problem for
+mission-critical applications.
 
 Using rafka we can:
 
-- Hide Kafka low-level details from the application and provide sane defaults,
-  backed by the excellent [librdkafka](https://github.com/edenhill/librdkafka).
-- Use a Redis client instead of a Kafka client. This particularly useful
-  in languages that lack a proper Kafka client library or do not provide
-  concurrency primitives to implement buffering and other optimizations. Furthermore,
-  writing a rafka client is much easier than writing a Kafka client. For a
-  list of available client libraries see [_Client libraries_](#client-libraries).
+- Hide Kafka low-level details from the application and provide sane defaults, backed by the
+  excellent [librdkafka](https://github.com/edenhill/librdkafka).
+- Use a Redis client instead of a Kafka client. This particularly useful in languages that lack a
+  proper Kafka client library or do not provide concurrency primitives to implement buffering and
+  other optimizations. Furthermore, writing a rafka client is much easier than writing a Kafka
+  client. For a list of available client libraries see [_Client libraries_](#client-libraries).
 
 Refer to [*"Introducing Kafka to a Rails application"*](https://engineering.skroutz.gr/blog/kafka-rails-integration/)
 for more background and how rafka is used in a production environment.
 
-
-
-
-
-
-
 Requirements
--------------------------------------------------------------------------------
+------------
 
 - [librdkafka](https://github.com/edenhill/librdkafka) 0.11.5 or later
 - A Kafka cluster
-
-
 
 Getting Started
 ------------
 
 1. Install [librdkafka](https://github.com/edenhill/librdkafka):
-   ```shell
-   # debian
-   $ sudo apt-get install librdkafka-dev
 
-   # macOS
-   $ brew install librdkafka
-   ```
+```shell
+# debian
+$ sudo apt-get install librdkafka-dev
+
+# macOS
+$ brew install librdkafka
+```
+
 2. Install rafka:
-   ```shell
-   $ go get -u github.com/skroutz/rafka
-   ```
+
+```shell
+$ go get -u github.com/skroutz/rafka
+```
+
 3. Run it:
-   ```shell
-   $ rafka -c librdkafka.json.sample
-   [rafka] 2017/06/26 11:07:23 Spawning Consumer Manager (librdkafka 0.11.0)...
-   [server] 2017/06/26 11:07:23 Listening on 0.0.0.0:6380
-   ```
 
-
+```shell
+$ rafka -c librdkafka.json.sample
+[rafka] 2017/06/26 11:07:23 Spawning Consumer Manager (librdkafka 0.11.0)...
+[server] 2017/06/26 11:07:23 Listening on 0.0.0.0:6380
+```
 
 Design
--------------------------------------------------------------------------------
+------
 
 ### Protocol
-rafka exposes a subset of the [Redis protocol](https://redis.io/topics/protocol)
-and tries to keep Redis semantics where possible.
 
-We also try to design the protocol in a way that rafka can be
-replaced by a plain Redis instance so that it's easier to test client code and
-libraries.
+rafka exposes a subset of the [Redis protocol](https://redis.io/topics/protocol) and tries to keep
+Redis semantics where possible.
 
-
-
-
+We also try to design the protocol in a way that rafka can be replaced by a plain Redis instance so
+that it's easier to test client code and libraries.
 
 ### Consumer
-In Kafka, each consumer represents a worker processing messages. That worker
-sends heartbeats and is de-pooled from its group when it misbehaves.
 
-Those semantics are preserved in rafka by using
-_stateful connections_. In rafka, each connection is tied with a set of Kafka
-consumers. Consumers are not shared between connections and once the
+In Kafka, each consumer represents a worker processing messages. That worker sends heartbeats and
+is de-pooled from its group when it misbehaves.
+
+Those semantics are preserved in rafka by using _stateful connections_. In rafka, each connection
+is tied with a set of Kafka consumers. Consumers are not shared between connections and once the
 connection closes, the respective consumers are gracefully shut down too.
 
-Each consumer must identify itself upon connection, by using `client setname
-<group.id>:<name>`. Then it can begin processing messages by issuing `blpop`
-calls on the desired topics. Each message should be explicitly acknowledged
-so it can be committed to Kafka. Acks are `rpush`ed to the special `acks` key.
-
-
+Each consumer must identify itself upon connection, by using `client setname <group.id>:<name>`.
+Then it can begin processing messages by issuing `blpop` calls on the desired topics. Each message
+should be explicitly acknowledged so it can be committed to Kafka. Acks are `rpush`ed to the
+special `acks` key.
 
 For more info refer to [API - Consumer](https://github.com/skroutz/rafka#consumer-1).
 
 #### Caveats
 
-rafka periodically calls [`Consumer.StoreOffsets()`](https://docs.confluent.io/current/clients/confluent-kafka-go/index.html#Consumer.StoreOffsets) under the hood. This means consumers must be
-configured accordingly:
+rafka periodically calls [`Consumer.StoreOffsets()`](https://docs.confluent.io/current/clients/confluent-kafka-go/index.html#Consumer.StoreOffsets)
+under the hood. This means consumers must be configured accordingly:
 
 - `enable.auto.commit` must be set to `true`
 - `enable.auto.offset.store` [must](https://github.com/edenhill/librdkafka/blob/v0.11.4/src/rdkafka.h#L2665) be set to `false`
@@ -113,58 +99,50 @@ configured accordingly:
 For more info see https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.
 
 ### Producer
-Each client connection is tied to a single Producer.
 
-Producers are not shared between connections and once the connection closes, its
-producer is also shutdown gracefully.
-
-Producers produce messages using `RPUSHX`.
-
-Produced messages are buffered in rafka and are eventually flushed
-to Kafka. However, `DUMP` can be used to force a synchronous flush of any
-outstanding messages.
-
+- Each client connection is tied to a single Producer.
+- Producers are not shared between connections and once the connection closes, its producer is also
+  shutdown gracefully.
+- Producers produce messages using `RPUSHX`.
+- Produced messages are buffered in rafka and are eventually flushed to Kafka. However, `DUMP` can
+  be used to force a synchronous flush of any outstanding messages.
 
 For more info refer to [API - Producer](https://github.com/skroutz/rafka#producer-1).
 
 #### Caveats
 
-There is currently is an upper message limit of **32MB** to the messages that
-may be produced. It is controlled by `go-redisproto.MaxBulkSize`.
-
-
+There is currently is an upper message limit of **32MB** to the messages that may be produced. It
+is controlled by `go-redisproto.MaxBulkSize`.
 
 API
-------------------------------------------------------------------------------
+---
 
 ### Producer
+
 - `RPUSHX topics:<topic> <message>` produce a message
-- `RPUSHX topics:<topic>:<key> <message>` produce a message with a partition key.
-   Messages with the same key will always be assigned to the same partition.
-- `DUMP <timeoutMs>` flush any outstanding messages to Kafka. This is a
-   blocking operation; it returns until all buffered messages are flushed or
-   the timeoutMs exceeds
+- `RPUSHX topics:<topic>:<key> <message>` produce a message with a partition key.  Messages with
+  the same key will always be assigned to the same partition.
+- `DUMP <timeoutMs>` flush any outstanding messages to Kafka. This is a blocking operation; it
+  returns until all buffered messages are flushed or the timeoutMs exceeds
 
 Example using redis-cli:
-```
+
+```shell
 127.0.0.1:6380> rpushx topics:greetings "hello there!"
 "OK"
 ```
 
-
-
-
-
 ### Consumer
+
 - `CLIENT SETNAME <group.id>:<name>` sets the consumer group and name
 - `CLIENT GETNAME`
-- `BLPOP topics:<topic>:<JSON-encoded consumer config> <timeoutMs>` consume
-   the next message from topic
-- `RPUSH acks <topic>:<partition>:<offset>` commit the offset for the given
-   topic/partition
+- `BLPOP topics:<topic>:<JSON-encoded consumer config> <timeoutMs>` consume the next message from
+  topic
+- `RPUSH acks <topic>:<partition>:<offset>` commit the offset for the given topic/partition
 
 Example using redis-cli:
-```
+
+```shell
 127.0.0.1:6380> client setname myapp:a-consumer
 "OK"
 127.0.0.1:6380> blpop topics:greetings 1000
@@ -181,73 +159,46 @@ Example using redis-cli:
 "OK"
 ```
 
-
-
-
-
-
 ### Generic
 
 - [`PING`](https://redis.io/commands/ping)
 - [`QUIT`](https://redis.io/commands/quit)
-- `HGETALL stats` get monitoring statistics
-  monitoring
+- `HGETALL stats` get monitoring statistics monitoring
 - `KEYS topics:` list all topics
 - `DEL stats` reset the monitoring statistics
 
-
-
-
-
-
-
-
 Client libraries
--------------------------------------------------------------------------------
+----------------
 
 - Ruby: [rafka-rb](https://github.com/skroutz/rafka-rb)
 
-
-
-
-
 Development
--------------------------------------------------------------------------------
+-----------
 
-
-If this is your first time setting up development on rafka, ensure that you
-have all the build dependencies via [dep](https://github.com/golang/dep):
+If this is your first time setting up development on rafka, ensure that you have all the build
+dependencies via [dep](https://github.com/golang/dep):
 
 ```shell
 $ dep ensure
 ```
 
-
 Running the Go tests:
+
 ```shell
 $ go test
 ```
 
-We also have end-to-end tests that run via Docker. Refer
-[here](test/README.md) for more information.
+We also have end-to-end tests that run via Docker. Refer [here](test/README.md) for more
+information.
 
+Run tests (must have done `make spawn` before), perform various static checks and finally build the
+project:
 
-Run tests (must have done `make spawn` before), perform various static checks
-and finally build the project:
 ```shell
 $ make
 ```
 
-
-
-
-
-
-
-
-
-
 License
--------------------------------------------------------------------------------
-rafka is released under the GNU General Public License version 3. See [COPYING](COPYING).
+-------
 
+rafka is released under the GNU General Public License version 3. See [COPYING](COPYING).

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"log"
@@ -23,12 +24,14 @@ import (
 	"strings"
 
 	rdkafka "github.com/confluentinc/confluent-kafka-go/kafka"
+	redisproto "github.com/secmask/go-redisproto"
 )
 
 type Client struct {
-	id   string
-	conn net.Conn
-	log  *log.Logger
+	id          string
+	conn        net.Conn
+	log         *log.Logger
+	monitorChan chan string
 
 	consManager *ConsumerManager
 	consGID     string
@@ -44,13 +47,27 @@ type Client struct {
 func NewClient(conn net.Conn, cm *ConsumerManager) *Client {
 	id := conn.RemoteAddr().String()
 
-	return &Client{
+	client := &Client{
 		id:          id,
+		monitorChan: make(chan string, 1000),
 		conn:        conn,
 		log:         log.New(os.Stderr, fmt.Sprintf("[client-%s] ", id), log.Ldate|log.Ltime),
 		consManager: cm,
 		consumers:   make(map[ConsumerID]bool),
 		consByTopic: make(map[string]ConsumerID),
+	}
+
+	go client.monitorWriter()
+
+	return client
+}
+
+// monitorWriter streams any monitor strings written to the client's monitor channel.
+func (c *Client) monitorWriter() {
+	writer := redisproto.NewWriter(bufio.NewWriter(c.conn))
+	for monitorOutput := range c.monitorChan {
+		writer.WriteSimpleString(monitorOutput)
+		writer.Flush()
 	}
 }
 
@@ -156,5 +173,6 @@ func (c *Client) Close() {
 		c.producer.Close()
 	}
 
+	close(c.monitorChan)
 	c.conn.Close()
 }


### PR DESCRIPTION
[MONITOR](https://redis.io/commands/monitor) is a debugging command that streams back every command processed by the Redis server. Since Rafka does not log the commands that the server handles, adding the ability to _"attach a terminal on server"_ and listen to all requests received by the server in real-time, would be a quite useful addition in order to spot bugs easier in a Rafka application.

To enable this functionality, we add an extra channel to the `Client` struct, the `monitorChan`. A separate goroutine that is spawned at client's creation time, will stream any data written to that channel on the client's socket. On server-side, we maintain a syncmap of the clients' monitoring channels, named `monitorChans`. Each time a _MONITOR_ command is triggered, the respective client's channel is appended to that map. Another goroutine named `monitorHandler` is in-charge of writing every command received by the Rafka server to the respective clients' channels via the main `srvMonitorChan` channel.

The format of the monitor command mimics the Redis equivalent output, and it's the following:

`
<unixTimestamp> [0 <client.id>] "<command>" "<arg1>" ... "<argN>"
`

Finally, some cleanup actions are applied to the project's README file **but** without affecting any of the existing documentation. The most important of those are the following:

- drop all unnecessary empty lines from the file
- trip unnecessary leading spaces
- wrap all lines to 100 chars length (no consistency currently)
- add missing newlines between titles and paragraphs

---

Apparently, this feature should be used with caution since attaching monitoring shells to a Rafka server comes with a cost. To illustrate that cost, I've run a (quite naive) testing scenario which measures the consuming throughput of _100k_ message from a single Rafka consumer on a host with _4 cpus_ (_Intel(R) Core(TM) i5-7300U CPU @ 2.60GHz_) and _16gb_ of memory. Note that the hardware specs where the testsuite was run, are not that important since the main rationale is to illustrate how multiple _MONITORing_ shells may affect the application's performance and **not** to mimic a production-like setup.

Below, I present the results of the aforementioned scenario. It's quite clear how the throughput rate is affected by increasing the attaching monitoring shells on a Rafka server:

| Active monitors | Consuming Time (100k msgs) | Throughput |
|----------------------------|------------|----------------------|
| - | 23.1029sec | ~4330msgs/sec |
| 1 | 28.2468sec | ~3541msgs/sec |
| 5 | 35.7541sec | ~2797msgs/sec |

> For reference, it took at around _22.3717sec_ for a Rafka _v0.4.0_ consumer to consume those messages.

That decrease in consumer's throughput as the monitoring clients increase, is mainly justified by
the increased number of _Write_ calls that the monitoring clients make in order to flush the running
commands into their sockets. There's also an overhead for scheduling the extra goroutines however it looks negligible comparing to the _Write_ calls' overhead. This can also be confirmed by listing the _pprof_ results of the _15 most CPU consuming entities_ after running the aforementioned scenario with //zero// and //5// active monitoring clients attached on the Rafka server:

```shell
# Active monitors: 0
(pprof) top15 -cum
Showing nodes accounting for 3s, 40.00% of 7.50s total
Dropped 166 nodes (cum <= 0.04s)
Showing top 15 nodes out of 139
      flat  flat%   sum%        cum   cum%
     0.05s  0.67%  0.67%      4.65s 62.00%  main.(*Server).Handle
         0     0%  0.67%      4.65s 62.00%  main.(*Server).ListenAndServe.func3
     0.01s  0.13%   0.8%      1.96s 26.13%  runtime.mcall
         0     0%   0.8%      1.94s 25.87%  runtime.park_m
     0.03s   0.4%  1.20%      1.92s 25.60%  runtime.schedule
     1.48s 19.73% 20.93%      1.60s 21.33%  syscall.Syscall
     0.07s  0.93% 21.87%      1.49s 19.87%  runtime.findrunnable
     1.30s 17.33% 39.20%      1.30s 17.33%  runtime.futex
         0     0% 39.20%      1.12s 14.93%  bufio.(*Writer).Flush
         0     0% 39.20%      1.12s 14.93%  github.com/skroutz/rafka/vendor/github.com/secmask/go-redisproto.(*Writer).Flush
     0.01s  0.13% 39.33%      1.12s 14.93%  net.(*conn).Write
     0.01s  0.13% 39.47%      1.11s 14.80%  net.(*netFD).Write
     0.01s  0.13% 39.60%      1.10s 14.67%  internal/poll.(*FD).Write
     0.01s  0.13% 39.73%      1.07s 14.27%  syscall.Write
     0.02s  0.27% 40.00%      1.06s 14.13%  syscall.write
```

```shell
# Active monitors: 5
(pprof) top15 -cum
Showing nodes accounting for 7.87s, 38.19% of 20.61s total
Dropped 277 nodes (cum <= 0.10s)
Showing top 15 nodes out of 127
      flat  flat%   sum%        cum   cum%
     0.06s  0.29%  0.29%      7.58s 36.78%  main.(*Server).Handle
         0     0%  0.29%      7.58s 36.78%  main.(*Server).ListenAndServe.func3
     7.08s 34.35% 34.64%      7.45s 36.15%  syscall.Syscall
     0.02s 0.097% 34.74%      7.28s 35.32%  github.com/skroutz/rafka/vendor/github.com/secmask/go-redisproto.(*Writer).Flush
     0.08s  0.39% 35.13%      7.26s 35.23%  bufio.(*Writer).Flush
     0.02s 0.097% 35.23%      7.16s 34.74%  net.(*conn).Write
     0.09s  0.44% 35.66%      7.14s 34.64%  net.(*netFD).Write
     0.04s  0.19% 35.86%      7.05s 34.21%  internal/poll.(*FD).Write
     0.01s 0.049% 35.90%      6.74s 32.70%  syscall.Write
     0.04s  0.19% 36.10%      6.73s 32.65%  syscall.write
     0.06s  0.29% 36.39%      6.22s 30.18%  main.(*Client).monitorWriter
     0.06s  0.29% 36.68%      3.69s 17.90%  runtime.mcall
     0.01s 0.049% 36.73%      3.62s 17.56%  runtime.park_m
     0.10s  0.49% 37.21%      3.54s 17.18%  runtime.schedule
     0.20s  0.97% 38.19%      2.72s 13.20%  runtime.findrunnable
```