### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 ## master (unreleased)
 
 
+## 0.6.0 (2019-10-08)
+
+This is a release refactoring the internal data structures of Rafka as detailed in [Rafka
+Rethinking](https://github.com/skroutz/rafka/blob/master/docs/designs/design-rafka-rethinking.rst)
+design doc.
+
+### Changed
+
+- [BREAKING] Drop support for multiple Consumers per Client. From now on, only a [single Consumer can be
+  associated with a Client instance](https://github.com/skroutz/rafka/blob/master/docs/designs/design-rafka-rethinking.rst#redefine-rafka-scope)
+
+- [INTERNAL] The ConsumerManager module as well as the respective functionality for managing
+  Consumers has been [completely dropped from the
+  source](https://github.com/skroutz/rafka/blob/master/docs/designs/design-rafka-rethinking.rst#drop-redundant-functionality).
+  Now, the handling of Consumers is split between the Server and the respective Client instances.
+
+
 ## 0.5.0 (2019-08-29)
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const Version = "0.5.0"
+const Version = "0.6.0"
 
 var (
 	cfg      Config


### PR DESCRIPTION
This release refactors the internal data structures of Rafka. The external API and generally any
interaction with existing functionality is not affected. In short it implements the [Redefine Rafka
scope](https://github.com/skroutz/rafka/blob/master/docs/designs/design-rafka-rethinking.rst#redefine-rafka-scope) and [Drop redundant functionality](https://github.com/skroutz/rafka/blob/master/docs/designs/design-rafka-rethinking.rst#drop-redundant-functionality) proposals of the [Rafka Rethinking](https://github.com/skroutz/rafka/blob/master/docs/designs/design-rafka-rethinking.rst) design doc.

> **Note:** Initially we were targeting v1.0.0. However, since Rafka semantics remain intact there's no actual need to bump to `v1.0.0` for now; furthermore we should better "save" `v1.0.0` numbering for the time Rafka is more mature in terms of monitoring, statistics, etc.