### PR TITLE
Release version 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 ## master (unreleased)
 
 
+## 0.6.1 (2019-10-09)
+
+This is a maintenance release with no changes.
+
 ## 0.6.0 (2019-10-08)
 
 This is a release refactoring the internal data structures of Rafka as detailed in [Rafka

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const Version = "0.6.0"
+const Version = "0.6.1"
 
 var (
 	cfg      Config


### PR DESCRIPTION
This is a maintenance release with a minor change; we've just added `debian/buster` to branches safelist.