### PR TITLE
test: Allow configuring Debian and librdkafka versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ before_script:
   - cd $TRAVIS_BUILD_DIR
 script:
   - make test
+matrix:
+  include:
+    - env: "DIST=stretch RDKAFKA_VERSION=v0.11.6"
+    - env: "DIST=stretch RDKAFKA_VERSION=v1.2.1"
+    - env: "DIST=buster RDKAFKA_VERSION=v0.11.6"
+    - env: "DIST=buster RDKAFKA_VERSION=v1.2.1"
+jobs:
+  allow_failures:
+    - env: "DIST=buster RDKAFKA_VERSION=v0.11.6"
 notifications:
   slack:
     secure: KDA5GK4A6P3rBWlS+UpU5jVTXKWlbljEB9cpdkX23geCPZXuhYKsr50wXPACN0cCLwH+v3LPyfBS7UGCP1I9OjK0/7ersOc+laQl9R75oNTxrlNgVsi9y23cNtBHmBpqFUAYNsXH7Why4+AdF6n/PnlOTFgUgiUwL5X8CIIYmRdOWCsQVCv7ZV1JzGUx7E3fXRr5QIWlqh7/xTGcQoyuKr11Rb/H4Q1hIA5OPgmecfjeMCsnXTv73OqFYoqEj5Kk2koRPFw7Z3G4QecIPdkhApA+M037gjZWCzXXiDysfgESDtE3XAgj4rMNnUMwTH8C68ftH1LtGd5eBwp98wmtj4mMJKue0RQrgxBqoxsyHpZJJ2dSERh78zy+G6guzm7EXkb8hy+OMJr1MZhWZ1FjLpZxQdKVF0cOgGvn+C0qgna8418kfZRBqosK2aHFPW2FjFMEOK0FkCNSE3g8uiobS0plZMTu7Cwu3uI95nmJ0x+05w7nFZM9CkPa2ZE1rcneKDJmNuoexP3TlCxX1FY8MXjC+XIVGGNSiA/tgRD+uivrZicY6NLMfy7WFLez1nBZPDGer0Uj1SCgw0M0wh3vKfwqZQuzhuHVgDNHKvPKdnswut3tuG7Mx83H9XNrm7OVCseDskFkRg+aUcquTWF2gPsJQW+FkvJ3gBUMOZqUaM4=

--- a/README.md
+++ b/README.md
@@ -201,20 +201,10 @@ dependencies via [dep](https://github.com/golang/dep):
 $ dep ensure
 ```
 
-Running the Go tests:
+To run all the tests (Go + end-to-end) do:
 
 ```shell
-$ go test
-```
-
-We also have end-to-end tests that run via Docker. Refer [here](test/README.md) for more
-information.
-
-Run tests (must have done `make spawn` before), perform various static checks and finally build the
-project:
-
-```shell
-$ make
+$ DIST=buster RDKAFKA_VERSION=v1.2.1 make test
 ```
 
 License

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:stretch
+# DIST and RDKAFKA_VERSION are required build arguments.
+ARG DIST
+FROM debian:${DIST}
+
+ARG RDKAFKA_VERSION
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -10,16 +14,20 @@ ADD skroutz-stable.list /etc/apt/sources.list.d/
 ADD skroutz-pu.list /etc/apt/sources.list.d/
 RUN curl -sSL http://debian.skroutz.gr/skroutz.asc | apt-key add -
 
-RUN apt-get update && \
-    apt-get install -y librdkafka-dev -t stretch-skroutz-proposed-updates && \
+RUN apt-get update &&  \
     apt-get install -y \
-        golang \
-        go-dep \
-        ruby-full \
-        bundler \
-        git \
-        confluent-kafka-2.11 \
-        openjdk-8-jdk
+      golang \
+      go-dep \
+      git \
+      ruby-full \
+      bundler \
+      confluent-kafka-2.11 \
+      default-jre
+
+# build librdkafka
+RUN git clone git://github.com/edenhill/librdkafka /tmp/librdkafka
+WORKDIR /tmp/librdkafka
+RUN git checkout ${RDKAFKA_VERSION} && ./configure --libdir=/usr/lib/$(dpkg-architecture -q DEB_HOST_GNU_TYPE) && make && make install
 
 ENV GOPATH /root/go
 ENV RAFKA rafka:6380

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem "rafka", "0.4.0"
+gem "rafka", "0.5.0"
 gem "minitest"

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -2,16 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.11.3)
-    rafka (0.4.0)
-      redis (~> 3, >= 3.3.2)
-    redis (3.3.5)
+    rafka (0.5.0)
+      redis (>= 3.3.2)
+    redis (4.1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   minitest
-  rafka (= 0.4.0)
+  rafka (= 0.5.0)
 
 BUNDLED WITH
-   1.13.6
+   1.17.3

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: skroutz/rafka
     build:
       context: .
+      args:
+        - DIST
+        - RDKAFKA_VERSION
     volumes:
     - ${GOPATH}/src/github.com/skroutz/rafka:/root/go/src/github.com/skroutz/rafka
     container_name: rafka


### PR DESCRIPTION
This patchset enables us to set the Debian and librdkafka versions to use when running the tests. It then updates our Travis build to leverage this feature and test in both Debian Buster and Stretch with librdkafka 0.11.6 and 1.2.1.