### PR TITLE
systemd: restart rafka on failure

### DIFF
--- a/debian/service
+++ b/debian/service
@@ -15,6 +15,7 @@ PrivateDevices=yes
 ProtectHome=yes
 ReadOnlyPaths=/
 LimitNOFILE=16384
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since this is a critical piece of software, we should automatically
restart it if/when it fails.