### PR TITLE
Producer ignorable events

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -69,13 +69,12 @@ func (p *Producer) Produce(msg *rdkafka.Message) error {
 // outstanding messages.
 func (p *Producer) Flush(timeoutMs int) int {
 	return p.rdProd.Flush(timeoutMs)
-
 }
 
 // Close stops p after flushing any buffered messages. It is a blocking
 // operation.
 func (p *Producer) Close() {
-	unflushed := p.rdProd.Flush(5000)
+	unflushed := p.Flush(5000)
 	if unflushed > 0 {
 		p.log.Printf("Error flushing: %d unflushed events", unflushed)
 		atomic.AddUint64(&stats.producerUnflushed, uint64(unflushed))

--- a/producer.go
+++ b/producer.go
@@ -98,7 +98,15 @@ func (p *Producer) consumeDeliveries() {
 			}
 		} else {
 			p.log.Printf("Error consuming delivery event: Unknown event type (%s)", ev)
-			atomic.AddUint64(&stats.producerErr, 1)
+
+			// We can ignore 'connection reset by peer' connection errors.
+			// See https://github.com/edenhill/librdkafka/wiki/FAQ#why-am-i-seeing-receive-failed-disconnected
+			// See https://github.com/skroutz/rafka/pull/90
+			if strings.Contains(ev.String(), "Connection reset by peer") {
+				continue
+			}
+
+			atomic.AddUint64(&stats.producerUnknownEvents, 1)
 		}
 	}
 }

--- a/stats.go
+++ b/stats.go
@@ -20,8 +20,9 @@ import (
 )
 
 type Stats struct {
-	producerUnflushed uint64
-	producerErr       uint64
+	producerUnflushed     uint64
+	producerErr           uint64
+	producerUnknownEvents uint64
 }
 
 func (s *Stats) toRedis() []interface{} {
@@ -30,10 +31,13 @@ func (s *Stats) toRedis() []interface{} {
 		strconv.FormatUint(atomic.LoadUint64(&s.producerUnflushed), 10),
 		"producer.delivery.errors",
 		strconv.FormatUint(atomic.LoadUint64(&s.producerErr), 10),
+		"producer.unknown.events",
+		strconv.FormatUint(atomic.LoadUint64(&s.producerUnknownEvents), 10),
 	}
 }
 
 func (s *Stats) Reset() {
 	atomic.StoreUint64(&s.producerUnflushed, 0)
 	atomic.StoreUint64(&s.producerErr, 0)
+	atomic.StoreUint64(&s.producerUnknownEvents, 0)
 }


### PR DESCRIPTION
From [confluent-kafka-go documentation](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/kafka.go#L74-L78):

```go
// * Producing is an asynchronous operation so the client notifies the application
// of per-message produce success or failure through something called delivery reports.
// Delivery reports are by default emitted on the `.Events()` channel as `*kafka.Message`
// and you should check `msg.TopicPartition.Error` for `nil` to find out if the message
// was succesfully delivered or not.
```

However, what they do not mention is that the `.Events()` channel does not always consist of `*kafka.Message`s. This is not so obvious, however they somewhat admit it in the [how to setup the producer example](https://github.com/confluentinc/confluent-kafka-go/blob/master/examples/producer_channel_example/producer_channel_example.go#L48-L66):

```go
switch ev := e.(type) {
case *kafka.Message:
  ...
  return

default:
  fmt.Printf("Ignored event: %s\n", ev)
```

Not only do they say "not all objects in the events channel are kafka messages", but they are also ignorrable (you can optionally log them).

What we present as _producer errors_ are actually these ignorable events, and not _delivery reports_ about delivery failures. We do this in the [producer](https://github.com/skroutz/rafka/blob/v0.6.1/producer.go#L102) and this was most likely done because of a [misunderstanding](https://github.com/skroutz/rafka/commit/04ac92c71cac367325ed422be5f5b7b193ec0970) of what these non-kafka-messages were.

The message is:
```
Sep  3 01:07:50 foo rafka[9730]: [producer-49582] 2020/09/03 01:07:50 Error consuming delivery event: Unknown event type (broker:9092/4: Receive failed: Connection reset by peer (after 1199998ms in state UP))
```

The `Error consuming delivery event: Unknown event type` part is from us, from rafka.
The `Receive failed` part is from [librdkafka](https://github.com/edenhill/librdkafka/blob/v0.11.6/src/rdkafka_broker.c#L1432-L1433).
The `Connection reset by peer` part is from tcp, from when [recv](https://github.com/edenhill/librdkafka/blob/master/src/rdkafka_transport.c#L303-L305) returns [ECONNRESET](https://linux.die.net/man/3/recv) . This means that the connection with the broker (peer) has been lost. 
The `(after 1199998ms in state UP)` part is also from librdkafka.

### Q1 Why/how do we get this string in the `.Events()` channel?

`.Events()` consist of many types of structures as we can see from the [poller](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/producer.go#L606-L621) and the [eventPoll](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/event.go#L154-L358) method.

### Q2 Why are we getting those disconnections?

The librdkafka devs have already made a [list](https://github.com/edenhill/librdkafka/wiki/FAQ#why-am-i-seeing-receive-failed-disconnected) of things that could be happening. While the first bullet on that list sounds like the most likely scenario, it is worthy of mention, that they have somehow tried to patch up that behavior with [this commit](https://github.com/edenhill/librdkafka/commit/bea2d634459a18d970fea29e69329efaa294101b):

```
The broker will disconnect clients that have not sent any protocol requests
within `connections.max.idle.ms` (broker configuration propertion, defaults
to 10 minutes), but there is no fool proof way for the client to know that it
was a deliberate close by the broker and not an error. To avoid logging these
deliberate idle disconnects as errors the client employs some logic to try to
classify a disconnect as an idle disconnect if no requests have been sent in
the last `socket.timeout.ms` or there are no outstanding, or
queued, requests waiting to be sent. In this case the standard "Disconnect"
error log is silenced (will only be seen with debug enabled).
```

It seems to me that if what we are seeing is indeed idle connection reaping, it should be handled more gracefully.
However, even the developers actually [suggest that we do not take that behavior for granted](https://github.com/edenhill/librdkafka/commit/bea2d634459a18d970fea29e69329efaa294101b#diff-1fe6ecc0e3e1fe5d73d83bc8e8381822c5cc10b0d96306fddab9d46ef671b576R486-R491) in the comments.
 
My suggestion is to look into the options provided and maybe adjust, after having more data regading whether it is the broker that disconnects because of idling etc (for example increase the `socket.timeout.ms`).

**This is most probably something we can ignore and no messages are being lost.**