### PR TITLE
QoL upgrades - go modules and automatic builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Compile the code
+      run: podman run --rm -v $(pwd):/app --workdir=/app golang:1.15 make build
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: rafka

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,36 +3,59 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:3050cda1d2bb57e8f27326397e165dd1c59668bb0cbb592f82f2be3a0106edae"
   name = "github.com/agis/spawn"
   packages = ["."]
+  pruneopts = ""
   revision = "2b1649feb264e6da334b227f2233b76b8d88c96c"
 
 [[projects]]
+  digest = "1:d091b4c15112c3a24dc5b1b03290a0076fececdc9944c06cb4b8ff039f80d00a"
   name = "github.com/confluentinc/confluent-kafka-go"
   packages = ["kafka"]
+  pruneopts = ""
   revision = "460e8e43b282a1a68219df600ef63442b81faf5f"
   version = "v0.11.6"
 
 [[projects]]
+  digest = "1:72688e2ecfbb1a5ea1775574945b4e76eb8f3c04f059d36fa8945459129908f3"
   name = "github.com/go-redis/redis"
-  packages = [".","internal","internal/consistenthash","internal/hashtag","internal/pool","internal/proto"]
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto",
+  ]
+  pruneopts = ""
   revision = "da63fe7def48e378caf9539abf64b9b1e37bc01e"
   version = "v6.5.3"
 
 [[projects]]
+  digest = "1:f3625b6d1dea2d58fe5bc8daec9595484ecc8687dd5187582b2b8f3e8dfb414a"
   name = "github.com/secmask/go-redisproto"
   packages = ["."]
+  pruneopts = ""
   revision = "14323b204640af1628764b06726c64fe040998e1"
 
 [[projects]]
+  digest = "1:58b484c6ec08df874223d884af3028b3bf0d3606bd44c60d533e161e22dbb7bd"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "a14d7d367bc02b1f57d88de97926727f2d936387"
   version = "v1.18.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b731e47c90c1ef552af3fedbf2e9bd578fa77c9925781c83042ed47bbec9f2f0"
+  input-imports = [
+    "github.com/agis/spawn",
+    "github.com/confluentinc/confluent-kafka-go/kafka",
+    "github.com/go-redis/redis",
+    "github.com/secmask/go-redisproto",
+    "github.com/urfave/cli",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,12 @@
 .PHONY: install dep build test teste2e testunit lint fmt clean run-rafka run-rafka-local testunit-local teste2e-local
 
-default: fmt install test
+default: fmt build
 
 install:
 	go install -v
 
-dep:
-	dep ensure -v
-
 build: fmt
-	CGO_ENABLED=1 go build -v -ldflags '-X main.VersionSuffix=$(shell git rev-parse HEAD)'
+	GOARCH=amd64 GOOS=linux CGO_ENABLED=1 go build -v -ldflags '-w -s -X main.VersionSuffix=$(shell git rev-parse HEAD)' -trimpath
 
 testunit-local:
 	go test -race
@@ -17,13 +14,14 @@ testunit-local:
 teste2e-local:
 	cd test && bundle install --frozen && ./end-to-end -v
 
-lint:
-	golint
-
 fmt:
-	test -z `go fmt 2>&1`
+	@if [ -n "$(shell gofmt -l . | grep -v vendor/)" ]; then \
+		echo "Source code needs re-formatting! Use 'go fmt' manually."; \
+		false; \
+	fi
 
 clean:
+	rm -rf vendor/
 	go clean
 
 run-rafka-local: build

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/skroutz/rafka
+
+go 1.15
+
+require (
+	github.com/agis/spawn v0.0.0-20180919161208-2b1649feb264
+	github.com/confluentinc/confluent-kafka-go v1.6.1
+	github.com/go-redis/redis v6.5.3+incompatible
+	github.com/secmask/go-redisproto v0.0.0-20170511031412-14323b204640
+	github.com/urfave/cli v1.18.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/agis/spawn v0.0.0-20180919161208-2b1649feb264 h1:em8RGASgYoKSlY1Zq1Piyx0PfgADeLLRjTugqk3Qolc=
+github.com/agis/spawn v0.0.0-20180919161208-2b1649feb264/go.mod h1:sF5dN6cOXWeyQd6YnItaxKFZ2rxDX/hDkHU5fQ3fAG0=
+github.com/confluentinc/confluent-kafka-go v0.11.6 h1:rEblubnNXCjRThwAGnFSzLKYIRAoXLDC3A9r4ciziHU=
+github.com/confluentinc/confluent-kafka-go v0.11.6/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/confluentinc/confluent-kafka-go v1.6.1 h1:YxM/UtMQ2vgJX2gIgeJFUD0ANQYTEvfo4Cs4qKUlmGE=
+github.com/confluentinc/confluent-kafka-go v1.6.1/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/go-redis/redis v6.5.3+incompatible h1:YcqfaCuHAccgVyFKRo/pclllia8de7/jEyZVw6XyM1A=
+github.com/go-redis/redis v6.5.3+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/secmask/go-redisproto v0.0.0-20170511031412-14323b204640 h1:utEYACgQyupsNdKFRnbDScTW4vRpJxR+UGIHDwOn3LY=
+github.com/secmask/go-redisproto v0.0.0-20170511031412-14323b204640/go.mod h1:jdj5Hw1t1c0xGmYOf3Rv4sM/nhbIP3RypZ29jGZjZ5A=
+github.com/urfave/cli v1.18.1 h1:IFc93MpteseEF1dvLEwx5Zn+K7xkbIcBGp36OwYlFx8=
+github.com/urfave/cli v1.18.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=


### PR DESCRIPTION
This PR aims to solve two main issues of rafka.

First of all, we upgrade rafka to use go modules. This is achieved while also keeping the same dependency versions. Since go has not introduced any breaking changes, we also take this change to upgrade go to 1.15 up from 1.11.

We also add a way to automatically build and release a new version of rafka each time a new tag is pushed in a branch (not just master). This allows for easily reproducible builds and less manual labor both when testing releases and main releases.